### PR TITLE
fix: toc special chars

### DIFF
--- a/@rocketseat/gatsby-theme-docs/package.json
+++ b/@rocketseat/gatsby-theme-docs/package.json
@@ -45,7 +45,6 @@
     "react-helmet": "^5.2.1",
     "react-icons": "^3.8.0",
     "react-live": "^2.2.2",
-    "slug": "^2.1.1",
     "url-join": "^4.0.1"
   },
   "devDependencies": {

--- a/@rocketseat/gatsby-theme-docs/src/components/Docs/TOC/index.js
+++ b/@rocketseat/gatsby-theme-docs/src/components/Docs/TOC/index.js
@@ -16,9 +16,7 @@ export default function TableOfContents({ headings }) {
               .filter(heading => heading.depth === 2)
               .map(heading => (
                 <li key={heading.value}>
-                  <a href={`#${slug(heading.value)}`}>
-                    {heading.value}
-                  </a>
+                  <a href={`#${slug(heading.value)}`}>{heading.value}</a>
                 </li>
               ))}
           </ul>

--- a/@rocketseat/gatsby-theme-docs/src/components/Docs/TOC/index.js
+++ b/@rocketseat/gatsby-theme-docs/src/components/Docs/TOC/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import slug from 'slug';
+
+import slug from '../../../util/slug';
 
 import { Container } from './styles';
 
@@ -15,7 +16,7 @@ export default function TableOfContents({ headings }) {
               .filter(heading => heading.depth === 2)
               .map(heading => (
                 <li key={heading.value}>
-                  <a href={`#${slug(heading.value, { lower: true })}`}>
+                  <a href={`#${slug(heading.value)}`}>
                     {heading.value}
                   </a>
                 </li>

--- a/@rocketseat/gatsby-theme-docs/src/util/slug.js
+++ b/@rocketseat/gatsby-theme-docs/src/util/slug.js
@@ -1,0 +1,8 @@
+export default function (string) {
+  return string
+    .toString()                     // Cast to string
+    .toLowerCase()                  // Convert the string to lowercase letters
+    .trim()                         // Remove whitespace from both sides of a string
+    .replace(/\s/g, '-')          // Replace each space with -
+    .replace(/[^\w\-\u00b4\u00C0-\u00C3\u00c7\u00C9-\u00CA\u00CD\u00D3-\u00D5\u00DA\u00E0-\u00E3\u00E7\u00E9-\u00EA\u00ED\u00F3-\u00F5\u00FA]+/g, '') // Removes all chars that aren't words, -, ´ or some latin characters (À Á Â Ã Ç É Ê Í Ó Ô Õ Ú à á â ã ç é ê í ó ô õ ú)
+}

--- a/@rocketseat/gatsby-theme-docs/src/util/slug.js
+++ b/@rocketseat/gatsby-theme-docs/src/util/slug.js
@@ -1,8 +1,11 @@
-export default function (string) {
+export default function(string) {
   return string
-    .toString()                     // Cast to string
-    .toLowerCase()                  // Convert the string to lowercase letters
-    .trim()                         // Remove whitespace from both sides of a string
-    .replace(/\s/g, '-')          // Replace each space with -
-    .replace(/[^\w\-\u00b4\u00C0-\u00C3\u00c7\u00C9-\u00CA\u00CD\u00D3-\u00D5\u00DA\u00E0-\u00E3\u00E7\u00E9-\u00EA\u00ED\u00F3-\u00F5\u00FA]+/g, '') // Removes all chars that aren't words, -, ´ or some latin characters (À Á Â Ã Ç É Ê Í Ó Ô Õ Ú à á â ã ç é ê í ó ô õ ú)
+    .toString() // Cast to string
+    .toLowerCase() // Convert the string to lowercase letters
+    .trim() // Remove whitespace from both sides of a string
+    .replace(/\s/g, '-') // Replace each space with -
+    .replace(
+      /[^\w\-\u00b4\u00C0-\u00C3\u00c7\u00C9-\u00CA\u00CD\u00D3-\u00D5\u00DA\u00E0-\u00E3\u00E7\u00E9-\u00EA\u00ED\u00F3-\u00F5\u00FA]+/g,
+      '',
+    ); // Removes all chars that aren't words, -, ´ or some latin characters (À Á Â Ã Ç É Ê Í Ó Ô Õ Ú à á â ã ç é ê í ó ô õ ú)
 }

--- a/examples/gatsby-theme-docs/src/pages/404.js
+++ b/examples/gatsby-theme-docs/src/pages/404.js
@@ -10,8 +10,8 @@ export default function NotFound() {
       <SEO title="404: Not found" />
       <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
       <p>
-        If you&#39;d like to go back to homepage,{' '}
-        <Link to="/">click here</Link>.
+        If you&#39;d like to go back to homepage, <Link to="/">click here</Link>
+        .
       </p>
     </Layout>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -14146,13 +14146,6 @@ slide@^1.1.6:
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
   integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
 
-slug@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-2.1.1.tgz#08df390d4b4d51bafb41ac0067c0c2dd70734ef2"
-  integrity sha512-yNGhDdS0DR0JyxnPC84qIx/Vd01RHVY4guJeBqBNdBoOLNWnzw5zkWJvxVSmsuUb92bikdnQFnw3PfGY8uZ82g==
-  dependencies:
-    unicode ">= 0.3.1"
-
 slugify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
@@ -15459,11 +15452,6 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
-
-"unicode@>= 0.3.1":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-12.1.0.tgz#7ee53a7a0ca5539b353419432823d8da58bbbf33"
-  integrity sha512-Ty6+Ew21DiYTWLYtd05RF/X4c1ekOvOgANyHbBj0h3MaXpfaGr2Rdmc0hMFuGQLyPLb9cU4ArNxl0bTF5HSzXw==
 
 unified@8.4.2, unified@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
**Changes proposed**
This PR fixes the TOC links. Before the changes, the anchor links didn't work with some special characters like latin vocabulary (eg.: ê). This behavior was happening because of the `slug` library. It was replacing common accented chars by non-accented ones.

Expected behavior
![unknown](https://user-images.githubusercontent.com/37725197/78418479-d26bf200-7612-11ea-84b6-5f22fd628c9a.png)

Actual behavior
![unknown (1)](https://user-images.githubusercontent.com/37725197/78418480-d39d1f00-7612-11ea-8bc8-7418a74ec8a1.png)

Because I didn't find any slug library that accepted these special chars, I've decided to create a `util` that formats the headings the way the library did, but adds some special chars.