### PR TITLE
Fix GitHub repository URL for getting started page

### DIFF
--- a/examples/gatsby-theme-docs/src/docs/getting-started.mdx
+++ b/examples/gatsby-theme-docs/src/docs/getting-started.mdx
@@ -5,7 +5,7 @@ title: 'Getting started'
 The best way yo start is by using our starter:
 
 ```bash
-gatsby new rocket-docs https://github.com/rocketseat/gatsby-starter-theme-docs
+gatsby new rocket-docs https://github.com/rocketseat/gatsby-starter-rocket-docs
 ```
 
 But, if you prefer, you can install and configure manually.


### PR DESCRIPTION
This now matches the README you have, before running the code would result in an error

<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/gatsby-themes/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
Change the GitHub repository URL in your rocketdocs "Getting Started" page because it was outdated and pointed to nothing causing an error during setup.
<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
