### PR TITLE
fix: separate yarn and npm commands

### DIFF
--- a/examples/gatsby-theme-docs/src/docs/getting-started.mdx
+++ b/examples/gatsby-theme-docs/src/docs/getting-started.mdx
@@ -11,11 +11,15 @@ npx gatsby new rocket-docs https://github.com/rocketseat/gatsby-starter-rocket-d
 
 But, if you prefer, you can install and configure manually.
 
-```bash
-# Using Yarn:
-yarn add @rocketseat/gatsby-theme-docs
+#### Using Yarn:
 
-# Using NPM:
+```bash
+yarn add @rocketseat/gatsby-theme-docs
+```
+
+#### Using NPM:
+
+```bash
 npm i @rocketseat/gatsby-theme-docs
 ```
 


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/gatsby-themes/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
Separated both commands now clicking on copy button only copies the respective command. Previously, it was copying both commands and comment,
<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->
