### PR TITLE
feat: new option, colors for blockquote and more

### DIFF
--- a/@rocketseat/gatsby-theme-docs-core/README.md
+++ b/@rocketseat/gatsby-theme-docs-core/README.md
@@ -51,15 +51,19 @@ npm i @rocketseat/gatsby-theme-docs-core
 
 ### Theme options
 
-| Key        | Default | Required | Description                                                                                                                                                            |
-| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| basePath   | /       | No       | Root url for all docs                                                                                                                                                  |
-| configPath | config  | No       | Location of config files                                                                                                                                               |
-| docsPath   | docs    | No       | The site description for SEO and social (FB, Twitter) tags                                                                                                             |
-| githubUrl  | -       | No       | The complete URL of your repository. For example: `https://github/rocketseat/gatsby-themes`                                                                            |
-| baseDir    | -       | No       | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (`docs`, for example)                                |
-| withMdx    | true    | No       | If necessary, you can add your own MDX options to the theme. To do so, make sure you turn this option to false and include `gatsby-plugin-mdx` on your `gatsby-config` |
-| branch     | main    | No       | Default branch of the repository                                                                                                                                       |
+| Key           | Default | Required | Description                                                                                                                                                            |
+| ------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| basePath      | /       | No       | Root url for all docs                                                                                                                                                  |
+| configPath    | config  | No       | Location of config files                                                                                                                                               |
+| docsPath      | docs    | No       | The site description for SEO and social (FB, Twitter) tags                                                                                                             |
+| githubUrl     | -       | -        | Deprecated in favor of `repositoryUrl`                                                                                                                                 |
+| repositoryUrl | -       | No       | The URL of your repository (supports GitHub, GitLab and Bitbucket). Example: `https://github/rocketseat/gatsby-themes`                                                 |
+| baseDir       | -       | No       | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (`docs`, for example)                                |
+| withMdx       | true    | No       | If necessary, you can add your own MDX options to the theme. To do so, make sure you turn this option to false and include `gatsby-plugin-mdx` on your `gatsby-config` |
+| branch        | main    | No       | Default branch of the repository                                                                                                                                       |
+
+> Note: When adding a BitBucket link on the `repositoryUrl` option, don't add the `src/<branch>` to it.
+> Example of correct link: `https://bitbucket.org/jpedroschmitz/gatsby-themes`
 
 ### Example usage
 

--- a/@rocketseat/gatsby-theme-docs-core/util/with-default.js
+++ b/@rocketseat/gatsby-theme-docs-core/util/with-default.js
@@ -4,7 +4,7 @@ module.exports = (themeOptions) => {
   const docsPath = themeOptions.docsPath || `docs`;
   const branch = themeOptions.branch || `main`;
   const baseDir = themeOptions.baseDir || ``;
-  const { githubUrl, withMdx = true } = themeOptions;
+  const { githubUrl, repositoryUrl, withMdx = true } = themeOptions;
 
   return {
     basePath,
@@ -12,6 +12,7 @@ module.exports = (themeOptions) => {
     docsPath,
     baseDir,
     githubUrl,
+    repositoryUrl,
     withMdx,
     branch,
   };

--- a/@rocketseat/gatsby-theme-docs/package.json
+++ b/@rocketseat/gatsby-theme-docs/package.json
@@ -32,7 +32,7 @@
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.0.0",
     "@mdx-js/react": "^1.6.18",
-    "@rocketseat/gatsby-theme-docs-core": "^1.2.0",
+    "@rocketseat/gatsby-theme-docs-core": "*",
     "gatsby-plugin-catch-links": "^3.0.0",
     "gatsby-plugin-emotion": "^6.0.0",
     "gatsby-plugin-mdx": "^2.0.0",

--- a/@rocketseat/gatsby-theme-docs/src/components/Docs/EditGithub.js
+++ b/@rocketseat/gatsby-theme-docs/src/components/Docs/EditGithub.js
@@ -3,13 +3,13 @@ import { useTheme, jsx, css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import { MdEdit } from 'react-icons/md';
 
-export default function EditGithub({ githubEditUrl }) {
+export default function EditGithub({ repositoryEditUrl, repositoryProvider }) {
   const theme = useTheme();
 
-  if (githubEditUrl) {
+  if (repositoryEditUrl) {
     return (
       <a
-        href={githubEditUrl}
+        href={repositoryEditUrl}
         target="_blank"
         rel="noopener noreferrer"
         css={css`
@@ -24,7 +24,7 @@ export default function EditGithub({ githubEditUrl }) {
         `}
       >
         <MdEdit style={{ marginRight: '5px' }} />
-        Edit this page on GitHub
+        Edit this page on {repositoryProvider}
       </a>
     );
   }
@@ -32,9 +32,11 @@ export default function EditGithub({ githubEditUrl }) {
 }
 
 EditGithub.propTypes = {
-  githubEditUrl: PropTypes.string,
+  repositoryEditUrl: PropTypes.string,
+  repositoryProvider: PropTypes.string,
 };
 
 EditGithub.defaultProps = {
-  githubEditUrl: null,
+  repositoryEditUrl: null,
+  repositoryProvider: null,
 };

--- a/@rocketseat/gatsby-theme-docs/src/components/Docs/index.js
+++ b/@rocketseat/gatsby-theme-docs/src/components/Docs/index.js
@@ -8,7 +8,7 @@ import PostNav from './PostNav';
 import EditGithub from './EditGithub';
 
 export default function Docs({ mdx, pageContext }) {
-  const { prev, next, githubEditUrl } = pageContext;
+  const { prev, next, repositoryEditUrl, repositoryProvider } = pageContext;
   const { title, description, image, disableTableOfContents } = mdx.frontmatter;
   const { headings, body } = mdx;
   const { slug } = mdx.fields;
@@ -22,7 +22,10 @@ export default function Docs({ mdx, pageContext }) {
         headings={headings}
       >
         <MDXRenderer>{body}</MDXRenderer>
-        <EditGithub githubEditUrl={githubEditUrl} />
+        <EditGithub
+          repositoryEditUrl={repositoryEditUrl}
+          repositoryProvider={repositoryProvider}
+        />
         <PostNav prev={prev} next={next} />
       </Layout>
     </>
@@ -46,6 +49,7 @@ Docs.propTypes = {
   pageContext: PropTypes.shape({
     prev: PropTypes.shape({}),
     next: PropTypes.shape({}),
-    githubEditUrl: PropTypes.string,
+    repositoryEditUrl: PropTypes.string,
+    repositoryProvider: PropTypes.string,
   }).isRequired,
 };

--- a/@rocketseat/gatsby-theme-docs/src/styles/global.js
+++ b/@rocketseat/gatsby-theme-docs/src/styles/global.js
@@ -100,9 +100,13 @@ export default function GlobalStyle() {
           p {
             padding: 1rem;
             border-radius: 5px;
-            background: ${theme.colors.shape};
-            color: ${theme.colors.text};
+            background: ${theme.colors.components.blockquote.background};
+            color: ${theme.colors.components.blockquote.text};
             margin: 0;
+
+            a {
+              color: ${theme.colors.components.blockquote.text};
+            }
           }
         }
 

--- a/@rocketseat/gatsby-theme-docs/src/styles/theme.js
+++ b/@rocketseat/gatsby-theme-docs/src/styles/theme.js
@@ -5,5 +5,11 @@ export default {
     shape: `#F2F2FA`,
     title: `#3D3D4D`,
     text: `#6C6C80`,
+    components: {
+      blockquote: {
+        background: `#feebc8`,
+        text: `#2d3748`,
+      },
+    },
   },
 };

--- a/examples/gatsby-theme-docs/gatsby-config.js
+++ b/examples/gatsby-theme-docs/gatsby-config.js
@@ -4,7 +4,7 @@ module.exports = {
     defaultTitle: `Rocket Docs`,
     siteTitleShort: `Rocket Docs`,
     siteDescription: `Out of the box Gatsby Theme for creating documentation websites easily and quickly`,
-    siteUrl: `https://rocketdocs.netlify.com`,
+    siteUrl: `https://rocketdocs.netlify.app`,
     siteAuthor: `@rocketseat`,
     siteImage: `/banner.png`,
     siteLanguage: `en`,
@@ -18,7 +18,7 @@ module.exports = {
       options: {
         configPath: `src/config`,
         docsPath: `src/docs`,
-        githubUrl: `https://github.com/rocketseat/gatsby-themes`,
+        repositoryUrl: `https://github.com/rocketseat/gatsby-themes`,
         baseDir: `examples/gatsby-theme-docs`,
       },
     },

--- a/examples/gatsby-theme-docs/src/docs/faq.mdx
+++ b/examples/gatsby-theme-docs/src/docs/faq.mdx
@@ -21,7 +21,10 @@ includes deploy tutorials for many services, like [Vercel](https://vercel.com/),
 
 ## What are good examples of the theme usage?
 
-Are you using this project? Submit a PR to add it to the list.
-
 - [Unform](https://unform.dev?utm_source=rocketseat_theme_docs)
 - [Botmation](https://botmation.dev)
+- [use-shopping-cart](https://useshoppingcart.com/)
+- [golangci-lint](https://golangci-lint.run/)
+- [Use Pandas](https://www.usepandas.com/)
+
+ps: are you using this project? Submit a PR to add it to the [list](https://github.com/Rocketseat/gatsby-themes/blob/main/examples/gatsby-theme-docs/src/docs/faq.mdx#what-are-good-examples-of-the-theme-usage).

--- a/examples/gatsby-theme-docs/src/docs/getting-started.mdx
+++ b/examples/gatsby-theme-docs/src/docs/getting-started.mdx
@@ -25,15 +25,21 @@ npm i @rocketseat/gatsby-theme-docs
 
 ## Theme Options
 
-| Key        | Default | Required | Description                                                                                                                                                            |
-| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| basePath   | /       | No       | Root url for all docs                                                                                                                                                  |
-| configPath | config  | No       | Location of config files                                                                                                                                               |
-| docsPath   | docs    | No       | The site description for SEO and social (FB, Twitter) tags                                                                                                             |
-| githubUrl  | -       | No       | The complete URL of your repository. For example: `https://github/rocketseat/gatsby-themes`                                                                            |
-| baseDir    | -       | No       | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (ex: `docs`)                                         |
-| withMdx    | true    | No       | If necessary, you can add your own MDX options to the theme. To do so, make sure you turn this option to false and include `gatsby-plugin-mdx` on your `gatsby-config` |
-| branch     | main    | No       | Default branch of the repository                                                                                                                                       |
+| Key           | Default | Required | Description                                                                                                                                                            |
+| ------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| basePath      | /       | No       | Root url for all docs                                                                                                                                                  |
+| configPath    | config  | No       | Location of config files                                                                                                                                               |
+| docsPath      | docs    | No       | The site description for SEO and social (FB, Twitter) tags                                                                                                             |
+| githubUrl     | -       | -        | Deprecated in favor of `repositoryUrl`                                                                                                                                 |
+| repositoryUrl | -       | No       | The complete URL of your repository (supports GitHub, GitLab and Bitbucket). Example: `https://github/rocketseat/gatsby-themes`                                        |
+| baseDir       | -       | No       | If your Gatsby site does not live in the root of your project directory/git repo, pass the subdirectory name here (ex: `docs`)                                         |
+| withMdx       | true    | No       | If necessary, you can add your own MDX options to the theme. To do so, make sure you turn this option to false and include `gatsby-plugin-mdx` on your `gatsby-config` |
+| branch        | main    | No       | Default branch of the repository                                                                                                                                       |
+
+<br />
+
+> Note: When adding a BitBucket link on the `repositoryUrl` option, don't add the `src/<branch>` to it.
+> Example of correct link: <br /> `https://bitbucket.org/jpedroschmitz/gatsby-themes`
 
 ## Example usage
 
@@ -44,7 +50,7 @@ module.exports = {
     defaultTitle: `@rocketseat/gatsby-theme-docs`,
     siteTitleShort: `gatsby-theme-docs`,
     siteDescription: `Out of the box Gatsby Theme for creating documentation websites easily and quickly`,
-    siteUrl: `https://rocketdocs.netlify.com`,
+    siteUrl: `https://rocketdocs.netlify.app`,
     siteAuthor: `@rocketseat`,
     siteImage: `/banner.png`,
     siteLanguage: `en`,
@@ -58,7 +64,7 @@ module.exports = {
         basePath: `/`,
         configPath: `src/config`,
         docsPath: `src/docs`,
-        githubUrl: `https://github.com/rocketseat/gatsby-themes`,
+        repositoryUrl: `https://github.com/rocketseat/gatsby-themes`,
         baseDir: `examples/gatsby-theme-docs`,
       },
     },

--- a/examples/gatsby-theme-docs/src/docs/usage/shadowing.mdx
+++ b/examples/gatsby-theme-docs/src/docs/usage/shadowing.mdx
@@ -79,6 +79,12 @@ export default {
     shape: `#F2F2FA`,
     title: `#3D3D4D`,
     text: `#6C6C80`,
+    components: {
+      blockquote: {
+        background: `#332616`,
+        text: `#E1E1E6`,
+      },
+    },
   },
 };
 ```


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/gatsby-themes/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

This PR adds a new option, `repositoryUrl`, that supports GitHub, GitLab, and BitBucket repository links. 
This option is necessary if you want to add an `Edit file on <provider>`  link at the docs.

We have also updated the background-colors on blockquote:

![Screen Shot 2021-03-09 at 20 22 19](https://user-images.githubusercontent.com/26466516/110552238-b7084180-8115-11eb-86e8-c8492b14e2b6.png)


**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->

Related to #47 
