### PR TITLE
fix: repositoryUrl listed as required but build fails when not included

### DIFF
--- a/.changeset/wise-queens-smell.md
+++ b/.changeset/wise-queens-smell.md
@@ -1,0 +1,5 @@
+---
+'@rocketseat/gatsby-theme-docs-core': patch
+---
+
+repositoryUrl listed as required but build fails when not included

--- a/@rocketseat/gatsby-theme-docs-core/gatsby-node.js
+++ b/@rocketseat/gatsby-theme-docs-core/gatsby-node.js
@@ -35,7 +35,10 @@ function generateRepositoryEditLink(themeOptions, relativePath) {
     };
   }
 
-  return null;
+  return {
+    editUrl: null,
+    provider: null,
+  };
 }
 
 exports.createPages = (

--- a/@rocketseat/gatsby-theme-docs-core/util/with-default.js
+++ b/@rocketseat/gatsby-theme-docs-core/util/with-default.js
@@ -4,7 +4,8 @@ module.exports = (themeOptions) => {
   const docsPath = themeOptions.docsPath || `docs`;
   const branch = themeOptions.branch || `main`;
   const baseDir = themeOptions.baseDir || ``;
-  const { githubUrl, repositoryUrl, withMdx = true } = themeOptions;
+  const withMdx = themeOptions.withMdx || true;
+  const { githubUrl, repositoryUrl = '' } = themeOptions;
 
   return {
     basePath,


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/gatsby-themes/blob/main/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
Removing `repositoryUrl` from the theme options causes the build to fail, this option is listed as not being required so the theme should handle this.

This fix should allow `repositoryUrl` to be omitted from the theme options if desired.

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
