### PR TITLE
fix: allow setting `withMdx` option to false

### DIFF
--- a/@rocketseat/gatsby-theme-docs-core/util/with-default.js
+++ b/@rocketseat/gatsby-theme-docs-core/util/with-default.js
@@ -4,7 +4,7 @@ module.exports = (themeOptions) => {
   const docsPath = themeOptions.docsPath || `docs`;
   const branch = themeOptions.branch || `main`;
   const baseDir = themeOptions.baseDir || ``;
-  const withMdx = themeOptions.withMdx || true;
+  const withMdx = themeOptions.withMdx === undefined ? true : themeOptions.withMdx;
   const { githubUrl, repositoryUrl = '' } = themeOptions;
 
   return {


### PR DESCRIPTION
The current check would always force it to be `true`

Addresses left-over problems from #24